### PR TITLE
feat: Show graph for file:// + optional isolation

### DIFF
--- a/feat/dependencies-of/cli.ts
+++ b/feat/dependencies-of/cli.ts
@@ -5,10 +5,22 @@ const flags = Flags.parse(Deno.args, {
   alias: {
     output: ['o'],
   },
+  boolean: [
+    'isolate-std',
+    'isolate-files',
+  ],
 });
 if (flags._.length !== 1) {
   console.error(`usage: cli.ts <path/to/module.ts> [-o output.{png,svg,jpg,jpeg}]`);
   Deno.exit(4);
+}
+
+const graphParams = new URLSearchParams();
+if (flags['isolate-std']) {
+  graphParams.set('std', 'isolate');
+}
+if (flags['isolate-files']) {
+  graphParams.set('files', 'isolate');
 }
 
 import { computeGraph, renderGraph } from "./compute.ts";
@@ -25,10 +37,10 @@ if (flags.output) {
   const dotProc = await renderGraph(modUrl, [
     `-o${flags.output}`,
     `-T${ext}`,
-  ], new URLSearchParams());
+  ], graphParams);
   console.log(await dotProc.captureAllTextOutput());
 
 } else {
-  const dotText = await computeGraph(modUrl, new URLSearchParams(), 'dot');
+  const dotText = await computeGraph(modUrl, graphParams, 'dot');
   console.log(dotText);
 }

--- a/lib/module-map.ts
+++ b/lib/module-map.ts
@@ -15,6 +15,7 @@ export class ModuleMap {
   ) {
     this.registryOpts = {
       mainModule: rootNode.specifier,
+      isolateFiles: this.args.get('files') === 'isolate',
       isolateStd: this.args.get('std') === 'isolate',
     }
 


### PR DESCRIPTION
@izelnakri ([context](https://github.com/denoland/deno_doc/issues/238)) was looking for a Deno graphviz tool which can be used locally, and noticed that I treat all local files as just one `file://` 'module':

![graph](https://user-images.githubusercontent.com/40628/151680186-929e2ac2-81b1-402b-9488-ecc3164733bf.png)

So I decided to use a better default of treating each **directory** as a module: (Note that `deps.ts` is special cased to prevent false-positive of cycles when subdirectories used the parent's `deps.ts`)

![graph](https://user-images.githubusercontent.com/40628/151680218-70f278d4-f98a-41d0-a9c3-f2d88fb84644.png)

And also added an `--isolate-files` CLI flag to make one node per file:

![graph](https://user-images.githubusercontent.com/40628/151680207-16f441b1-d179-4829-ad7c-f2d6d398d636.png)

Hoping this proves useful now.